### PR TITLE
Added conditional to manage long usernames

### DIFF
--- a/cas_provider/views.py
+++ b/cas_provider/views.py
@@ -246,6 +246,15 @@ def auth_success_response(user, pgt, proxies):
     username = etree.SubElement(auth_success, CAS + 'user')
     username.text = getattr(user, settings.CAS_USERNAME_FIELD)
 
+    if len(username.text) > 30:
+        if '@' in username.text[:30]:
+            username.text = username.text[:30]
+        elif username.text.endswith('@touchstonenetwork.net'):
+            username.text = username.text.rsplit(
+                '@touchstonenetwork.net')[0][:27] + '@tn'
+        else:
+            username.text = username.text[:29] + '@'
+
     if settings.CAS_CUSTOM_ATTRIBUTES_CALLBACK:
         callback = get_callable(settings.CAS_CUSTOM_ATTRIBUTES_CALLBACK)
         attrs = callback(user)


### PR DESCRIPTION
Usernames longer than 30 characters are truncated by edX which leads to
mismatches when trying to log in via CAS. Added a conditional block to
ensure that usernames are of an acceptable length, as well as containing
an @ symbol so that we can filter out non-MIT users from general enrollment.