### PR TITLE
Fixed cas url encoding issues

### DIFF
--- a/cas_provider/models.py
+++ b/cas_provider/models.py
@@ -49,8 +49,10 @@ class ServiceTicket(BaseTicket):
     def get_redirect_url(self):
         parsed = urlparse.urlparse(self.service)
         query = parse_qs(parsed.query)
+        # parse_qs converts plus(+) to space, to fix this issue using quote_plus
         query = [
-            ((k, v) if len(v) > 1 else (k, v[0]))
+            ((k, [urllib.quote_plus(data, safe='/:') for data in v])
+            if len(v) > 1 else (k, urllib.quote_plus(v[0], safe='/:')))
             for k, v in query.iteritems()
         ]
         query.append(('ticket', self.ticket))

--- a/cas_provider/tests.py
+++ b/cas_provider/tests.py
@@ -341,6 +341,15 @@ class ModelsTestCase(TestCase):
         ticket = ServiceTicket.objects.create(service='http://example.com', user=self.user)
         self.assertEqual(ticket.get_redirect_url(), '%(service)s?ticket=%(ticket)s' % ticket.__dict__)
 
+    def test_plus_encoding(self):
+        ticket = ServiceTicket.objects.create(
+            service='http://example.com/?next=/courses/course-v1:MITx+6.042r_4+2017_Fall/',
+            user=self.user
+        )
+        assert (
+            "next=%2Fcourses%2Fcourse-v1%3AMITx%2B6.042r_4%2B2017_Fall%2F" in ticket.get_redirect_url()
+        )
+
 
 def cas_mapping(user):
     return {


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/salt-ops/issues/409

#### What's this PR do?
There is an issue in master, [code](https://github.com/mitocw/django-cas-provider/blob/master/cas_provider/models.py#L51) decode plus(+) into space.

#### How should this be manually tested?
- You need to deploy it
- You can run test.
- Test below code on master and this branch
```python
import urllib
import urlparse
parse_qs = urlparse.parse_qs
service='http://example.com/?next=/courses/course-v1:MITx+6.042r_4+2017_Fall/'
parsed = urlparse.urlparse(service)
query = parse_qs(parsed.query)
query = [((k, [urllib.quote_plus(data) for data in v]) if len(v) > 1 else (k, urllib.quote_plus(v[0]))) for k, v in query.iteritems()]
parsed = urlparse.ParseResult(parsed.scheme, parsed.netloc,
                                      parsed.path, parsed.params,
                                      urllib.urlencode(query), parsed.fragment)
parsed.geturl()
```

@pdpinch 


